### PR TITLE
remove default image builder resources

### DIFF
--- a/controllers/resources/bentorequest_controller.go
+++ b/controllers/resources/bentorequest_controller.go
@@ -1737,16 +1737,6 @@ echo "Done"
 		TTY:             true,
 		Stdin:           true,
 		SecurityContext: builderContainerSecurityContext,
-		Resources: corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("1Gi"),
-			},
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("3Gi"),
-			},
-		},
 	}
 
 	if globalDefaultImageBuilderContainerResources != nil {


### PR DESCRIPTION
We no longer want defaults now we're using pod anti-affinity.