### PR TITLE
fix: port name when using multiple ports

### DIFF
--- a/helm/yatai-image-builder/templates/service.yaml
+++ b/helm/yatai-image-builder/templates/service.yaml
@@ -10,6 +10,7 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: 9443
+    name: https
   - port: 8080
     protocol: TCP
     targetPort: 8080


### PR DESCRIPTION
`The Service "yatai-image-builder-webhook-service" is invalid: spec.ports[1].name: Required value`