### PR TITLE
fix: use new-style env command

### DIFF
--- a/bento-downloader/Dockerfile
+++ b/bento-downloader/Dockerfile
@@ -20,4 +20,4 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     && ./google-cloud-sdk/install.sh \
     && rm google-cloud-cli-410.tar.gz
 
-ENV PATH $PATH:/google-cloud-sdk/bin
+ENV PATH=$PATH:/google-cloud-sdk/bin


### PR DESCRIPTION
Avoids a warning when building the container.
