### PR TITLE
chore: update helm charts

### DIFF
--- a/helm/yatai-image-builder/templates/_helpers.tpl
+++ b/helm/yatai-image-builder/templates/_helpers.tpl
@@ -86,6 +86,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "yatai-image-builder.builderServiceAccountName" -}}
+{{- if .Values.builder.serviceAccount.create }}
+{{- default ((printf "%s-builder" (include "yatai-image-builder.fullname" .)) | trunc 63 | trimSuffix "-") .Values.builder.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.builder.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Generate k8s robot token
 */}}
 {{- define "yatai-image-builder.yataiApiToken" -}}

--- a/helm/yatai-image-builder/templates/builder-configmap.yaml
+++ b/helm/yatai-image-builder/templates/builder-configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+immutable: false
+metadata:
+  name: yatai-image-builder-config
+  namespace: {{ .Release.Namespace }}
+data:
+  default_image_builder_container_resources: |
+    requests:
+      {{ .Values.builder.requests | toYaml | indent 6 }}
+    limits:
+      {{ .Values.builder.limits | toYaml | indent 6 }}
+  extra_pod_spec: |
+    nodeSelector:
+      {{ .Values.builder.nodeSelector | toYaml | indent 6 }}
+    tolerations:
+      {{ .Values.builder.tolerations | toYaml | indent 6 }}
+    affinity:
+      {{ .Values.builder.affinity | toYaml | indent 6 }}

--- a/helm/yatai-image-builder/templates/builder-serviceaccount.yaml
+++ b/helm/yatai-image-builder/templates/builder-serviceaccount.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.builder.serviceAccount.create -}}
+{{- range .Values.global.deploymentNamespaces }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "yatai-image-builder.builderServiceAccountName" . }}
-  namespace: {{ .Values.global.deploymentNamespace }}
+  namespace: {{ . }}
   labels:
     {{- include "yatai-image-builder.labels" . | nindent 4 }}
     "yatai.ai/yatai-image-builder-pod": "true"
@@ -11,4 +12,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/yatai-image-builder/templates/builder-serviceaccount.yaml
+++ b/helm/yatai-image-builder/templates/builder-serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.builder.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "yatai-image-builder.builderServiceAccountName" . }}
+  namespace: {{ .Values.global.deploymentNamespace }}
+  labels:
+    {{- include "yatai-image-builder.labels" . | nindent 4 }}
+    "yatai.ai/yatai-image-builder-pod": "true"
+  {{- with .Values.builder.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/yatai-image-builder/templates/builder-serviceaccount.yaml
+++ b/helm/yatai-image-builder/templates/builder-serviceaccount.yaml
@@ -3,12 +3,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "yatai-image-builder.builderServiceAccountName" . }}
+  name: {{ include "yatai-image-builder.builderServiceAccountName" $ }}
   namespace: {{ . }}
   labels:
-    {{- include "yatai-image-builder.labels" . | nindent 4 }}
+    {{- include "yatai-image-builder.labels" $ | nindent 4 }}
     "yatai.ai/yatai-image-builder-pod": "true"
-  {{- with .Values.builder.serviceAccount.annotations }}
+  {{- with $.Values.builder.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/helm/yatai-image-builder/templates/clusterrole-yatai-with-bento-request.yaml
+++ b/helm/yatai-image-builder/templates/clusterrole-yatai-with-bento-request.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.bentoRequestAllNamespaces }}
+{{- if .Values.global.monitorAllNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/yatai-image-builder/templates/clusterrole.yaml
+++ b/helm/yatai-image-builder/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.bentoRequestAllNamespaces }}
+{{- if .Values.global.monitorAllNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/helm/yatai-image-builder/templates/clusterrolebinding-yatai-with-bento-request.yaml
+++ b/helm/yatai-image-builder/templates/clusterrolebinding-yatai-with-bento-request.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.bentoRequestAllNamespaces }}
+{{- if .Values.global.monitorAllNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/yatai-image-builder/templates/clusterrolebinding-yatai-with-bento-request.yaml
+++ b/helm/yatai-image-builder/templates/clusterrolebinding-yatai-with-bento-request.yaml
@@ -9,6 +9,6 @@ roleRef:
   name: yatai-with-bento-request-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.yataiSystem.serviceAccountName }}
-  namespace: {{ .Values.yataiSystem.namespace }}
+  name: {{ .Values.global.yataiSystemServiceAccountName }}
+  namespace: {{ .Values.global.yataiSystemNamespace }}
 {{- end }}

--- a/helm/yatai-image-builder/templates/clusterrolebinding.yaml
+++ b/helm/yatai-image-builder/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.bentoRequestAllNamespaces }}
+{{- if .Values.global.monitorAllNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/helm/yatai-image-builder/templates/deployment.yaml
+++ b/helm/yatai-image-builder/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                   key: {{ .Values.dockerRegistry.passwordExistingSecretKey | quote }}
             {{- end }}
             - name: JUICEFS_STORAGE_CLASS_NAME
-              value: {{ .Values.juicefsStorageClassName | quote }}
+              value: juicefs-sc
           envFrom:
             - secretRef:
                 name: {{ include "yatai-image-builder.envname" . }}

--- a/helm/yatai-image-builder/templates/deployment.yaml
+++ b/helm/yatai-image-builder/templates/deployment.yaml
@@ -52,13 +52,6 @@ spec:
                   name: {{ .Values.dockerRegistry.passwordExistingSecretName | quote }}
                   key: {{ .Values.dockerRegistry.passwordExistingSecretKey | quote }}
             {{- end }}
-            {{- if .Values.aws.secretAccessKeyExistingSecretName }}
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.aws.secretAccessKeyExistingSecretName | quote }}
-                  key: {{ .Values.aws.secretAccessKeyExistingSecretKey | quote }}
-            {{- end }}
             - name: JUICEFS_STORAGE_CLASS_NAME
               value: {{ .Values.juicefsStorageClassName | quote }}
           envFrom:

--- a/helm/yatai-image-builder/templates/deployment.yaml
+++ b/helm/yatai-image-builder/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
                   key: {{ .Values.dockerRegistry.passwordExistingSecretKey | quote }}
             {{- end }}
             - name: JUICEFS_STORAGE_CLASS_NAME
-              value: juicefs-sc
+              value: {{ .Values.internal.juicefsStorageClassName }}
           envFrom:
             - secretRef:
                 name: {{ include "yatai-image-builder.envname" . }}

--- a/helm/yatai-image-builder/templates/deployment.yaml
+++ b/helm/yatai-image-builder/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       labels:
         {{- include "yatai-image-builder.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/yatai-image-builder/templates/deployment.yaml
+++ b/helm/yatai-image-builder/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8080
             - --leader-elect
-            - --skip-check={{ .Values.skipCheck }}
+            - --skip-check={{ .Values.internal.skipCheck }}
           command:
             - /manager
           env:

--- a/helm/yatai-image-builder/templates/range-role.yaml
+++ b/helm/yatai-image-builder/templates/range-role.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.bentoRequestNamespaces }}
+{{- range .Values.global.deploymentNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/yatai-image-builder/templates/range-rolebinding.yaml
+++ b/helm/yatai-image-builder/templates/range-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.bentoRequestNamespaces }}
+{{- range .Values.global.deploymentNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm/yatai-image-builder/templates/role-in-yatai-system-namespace.yaml
+++ b/helm/yatai-image-builder/templates/role-in-yatai-system-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "yatai-image-builder.serviceAccountNameInYataiSystemNamespace" . }}
-  namespace: {{ .Values.yataiSystem.namespace }}
+  namespace: {{ .Values.global.yataiSystemNamespace }}
 rules:
 - apiGroups:
   - ""

--- a/helm/yatai-image-builder/templates/role-yatai-in-yatai-system-namespace.yaml
+++ b/helm/yatai-image-builder/templates/role-yatai-in-yatai-system-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "yatai-image-builder.yatai-rolename-in-yatai-system-namespace" . }}
-  namespace: {{ .Values.yataiSystem.namespace }}
+  namespace: {{ .Values.global.yataiSystemNamespace }}
 rules:
 - apiGroups:
   - ""

--- a/helm/yatai-image-builder/templates/role-yatai-with-bento-request.yaml
+++ b/helm/yatai-image-builder/templates/role-yatai-with-bento-request.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.bentoRequestNamespaces }}
+{{- range .Values.global.deploymentNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/helm/yatai-image-builder/templates/rolebinding-in-yatai-system-namespace.yaml
+++ b/helm/yatai-image-builder/templates/rolebinding-in-yatai-system-namespace.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "yatai-image-builder.serviceAccountNameInYataiSystemNamespace" . }}
-  namespace: {{ .Values.yataiSystem.namespace }}
+  namespace: {{ .Values.global.yataiSystemNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/yatai-image-builder/templates/rolebinding-yatai-in-yatai-system-namespace.yaml
+++ b/helm/yatai-image-builder/templates/rolebinding-yatai-in-yatai-system-namespace.yaml
@@ -2,12 +2,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "yatai-image-builder.yatai-rolename-in-yatai-system-namespace" . }}
-  namespace: {{ .Values.yataiSystem.namespace }}
+  namespace: {{ .Values.global.yataiSystemNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "yatai-image-builder.yatai-rolename-in-yatai-system-namespace" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.yataiSystem.serviceAccountName }}
-    namespace: {{ .Values.yataiSystem.namespace }}
+    name: {{ .Values.global.yataiSystemServiceAccountName }}
+    namespace: {{ .Values.global.yataiSystemNamespace }}

--- a/helm/yatai-image-builder/templates/rolebinding-yatai-with-bento-request.yaml
+++ b/helm/yatai-image-builder/templates/rolebinding-yatai-with-bento-request.yaml
@@ -10,6 +10,6 @@ roleRef:
   name: yatai-with-bento-request
 subjects:
 - kind: ServiceAccount
-  name: {{ $.Values.yataiSystem.serviceAccountName }}
+  name: {{ $.Values.global.yataiSystemServiceAccountName }}
   namespace: {{ . | quote }}
 {{- end }}

--- a/helm/yatai-image-builder/templates/rolebinding-yatai-with-bento-request.yaml
+++ b/helm/yatai-image-builder/templates/rolebinding-yatai-with-bento-request.yaml
@@ -1,4 +1,4 @@
-{{- range .Values.bentoRequestNamespaces }}
+{{- range .Values.global.deploymentNamespaces }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm/yatai-image-builder/templates/rolebinding-yatai-with-yatai-image-builder.yaml
+++ b/helm/yatai-image-builder/templates/rolebinding-yatai-with-yatai-image-builder.yaml
@@ -9,5 +9,5 @@ roleRef:
   name: {{ include "yatai-image-builder.yatai-with-yatai-image-builder-rolename" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.yataiSystem.serviceAccountName }}
-    namespace: {{ .Values.yataiSystem.namespace }}
+    name: {{ .Values.global.yataiSystemServiceAccountName }}
+    namespace: {{ .Values.global.yataiSystemNamespace }}

--- a/helm/yatai-image-builder/templates/secret-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-env.yaml
@@ -42,7 +42,7 @@ stringData:
   BUILDKIT_S3_CACHE_BUCKET: {{ .Values.buildkit.s3Cache.bucket | quote }}
   BUILDKIT_CACHE_REPO: {{ .Values.buildkit.cacheRepo | quote }}
 
-  ESTARGZ_ENABLED: {{ .Values.estargz.enabled | quote }}
+  ESTARGZ_ENABLED: false
 
   KANIKO_CACHE_REPO: {{ .Values.kaniko.cacheRepo | quote }}
   KANIKO_SNAPSHOT_MODE: {{ .Values.kaniko.snapshotMode | quote }}

--- a/helm/yatai-image-builder/templates/secret-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-env.yaml
@@ -9,7 +9,7 @@ type: Opaque
 stringData:
   YATAI_IMAGE_BUILDER_SHARED_ENV_SECRET_NAME: {{ include "yatai-image-builder.shared-envname" . }}
 
-  YATAI_SYSTEM_NAMESPACE: {{ .Values.yataiSystem.namespace }}
+  YATAI_SYSTEM_NAMESPACE: {{ .Values.global.yataiSystemNamespace }}
   YATAI_API_TOKEN: {{ include "yatai-image-builder.yataiApiToken" . | quote }}
 
   DOCKER_REGISTRY_SERVER: {{ .Values.dockerRegistry.server | quote }}

--- a/helm/yatai-image-builder/templates/secret-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-env.yaml
@@ -21,19 +21,6 @@ stringData:
   DOCKER_REGISTRY_SECURE: {{ .Values.dockerRegistry.secure | quote }}
   DOCKER_REGISTRY_BENTO_REPOSITORY_NAME: {{ .Values.dockerRegistry.bentoRepositoryName | quote }}
 
-  {{- if .Values.aws.accessKeyID }}
-  AWS_ACCESS_KEY_ID: {{ .Values.aws.accessKeyID | quote }}
-  {{- end }}
-  {{- if .Values.aws.secretAccessKey }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.aws.secretAccessKey | quote }}
-  {{- end }}
-  {{- if .Values.gcp.accessKeyID }}
-  GCP_ACCESS_KEY_ID: {{ .Values.gcp.accessKeyID | quote }}
-  {{- end }}
-  {{- if .Values.gcp.secretAccessKey }}
-  GCP_SECRET_ACCESS_KEY: {{ .Values.gcp.secretAccessKey | quote }}
-  {{- end }}
-
   INTERNAL_IMAGES_BENTO_DOWNLOADER: {{ .Values.internalImages.bentoDownloader | quote }}
   INTERNAL_IMAGES_KANIKO: {{ .Values.internalImages.kaniko | quote }}
   INTERNAL_IMAGES_BUILDKIT: {{ .Values.internalImages.buildkit | quote }}

--- a/helm/yatai-image-builder/templates/secret-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-env.yaml
@@ -60,9 +60,9 @@ stringData:
   KANIKO_CACHE_REPO: {{ .Values.kaniko.cacheRepo | quote }}
   KANIKO_SNAPSHOT_MODE: {{ .Values.kaniko.snapshotMode | quote }}
 
-  CONTAINER_IMAGE_S3_ENDPOINT_URL: {{ .Values.containerImageS3Storage.endpointURL | quote }}
-  CONTAINER_IMAGE_S3_BUCKET: {{ .Values.containerImageS3Storage.bucket | quote }}
-  CONTAINER_IMAGE_S3_ENABLE_STARGZ: {{ .Values.containerImageS3Storage.enableStargz | quote }}
-  CONTAINER_IMAGE_S3_ACCESS_KEY_ID: {{ .Values.containerImageS3Storage.accessKeyID | quote }}
-  CONTAINER_IMAGE_S3_SECRET_ACCESS_KEY: {{ .Values.containerImageS3Storage.secretAccessKey | quote }}
-  CONTAINER_IMAGE_S3_SECURE: {{ .Values.containerImageS3Storage.secure | quote }}
+  CONTAINER_IMAGE_S3_ENDPOINT_URL: {{ .Values.global.s3.endpoint | quote }}
+  CONTAINER_IMAGE_S3_BUCKET: {{ .Values.global.s3.bucket | quote }}
+  CONTAINER_IMAGE_S3_ACCESS_KEY_ID: {{ .Values.global.s3.accessKeyID | quote }}
+  CONTAINER_IMAGE_S3_SECRET_ACCESS_KEY: {{ .Values.global.s3.secretAccessKey | quote }}
+  CONTAINER_IMAGE_S3_SECURE: {{ .Values.global.s3.secure | quote }}
+  CONTAINER_IMAGE_S3_ENABLE_STARGZ: false

--- a/helm/yatai-image-builder/templates/secret-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-env.yaml
@@ -46,7 +46,7 @@ stringData:
 
   BENTO_IMAGE_BUILD_ENGINE: {{ .Values.bentoImageBuildEngine | quote }}
 
-  DISABLE_YATAI_COMPONENT_REGISTRATION: {{ .Values.disableYataiComponentRegistration | quote }}
+  DISABLE_YATAI_COMPONENT_REGISTRATION: {{ .Values.internal.disableYataiComponentRegistration | quote }}
 
   ADD_NAMESPACE_PREFIX_TO_IMAGE_NAME: {{ .Values.addNamespacePrefixToImageName | quote }}
 

--- a/helm/yatai-image-builder/templates/secret-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-env.yaml
@@ -35,7 +35,7 @@ stringData:
 
   DISABLE_YATAI_COMPONENT_REGISTRATION: {{ .Values.internal.disableYataiComponentRegistration | quote }}
 
-  ADD_NAMESPACE_PREFIX_TO_IMAGE_NAME: {{ .Values.addNamespacePrefixToImageName | quote }}
+  ADD_NAMESPACE_PREFIX_TO_IMAGE_NAME: {{ .Values.global.multiTenant | quote }}
 
   BUILDKIT_S3_CACHE_ENABLED: {{ .Values.buildkit.s3Cache.enabled | quote }}
   BUILDKIT_S3_CACHE_REGION: {{ .Values.buildkit.s3Cache.region | quote }}

--- a/helm/yatai-image-builder/templates/secret-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-env.yaml
@@ -53,3 +53,10 @@ stringData:
   CONTAINER_IMAGE_S3_SECRET_ACCESS_KEY: {{ .Values.global.s3.secretAccessKey | quote }}
   CONTAINER_IMAGE_S3_SECURE: {{ .Values.global.s3.secure | quote }}
   CONTAINER_IMAGE_S3_ENABLE_STARGZ: false
+
+  {{- if .Values.internal.aws.accessKeyID }}
+  AWS_ACCESS_KEY_ID: {{ .Values.aws.accessKeyID | quote }}
+  {{- end }}
+  {{- if .Values.internal.aws.secretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.aws.secretAccessKey | quote }}
+  {{- end }}

--- a/helm/yatai-image-builder/templates/secret-shared-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-shared-env.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "yatai-image-builder.shared-envname" . }}
-  namespace: {{ .Values.yataiSystem.namespace }}
+  namespace: {{ .Values.global.yataiSystemNamespace }}
   labels:
     {{- include "yatai-image-builder.labels" . | nindent 4 }}
 type: Opaque

--- a/helm/yatai-image-builder/templates/secret-yatai-common-env.yaml
+++ b/helm/yatai-image-builder/templates/secret-yatai-common-env.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "yatai-image-builder.yatai-common-envname" . }}
-  namespace: {{ .Values.yataiSystem.namespace }}
+  namespace: {{ .Values.global.yataiSystemNamespace }}
   labels:
     {{- include "yatai-image-builder.labels" . | nindent 4 }}
 type: Opaque

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -142,3 +142,7 @@ internal:
   disableYataiComponentRegistration: true
   skipCheck: false
   juicefsStorageClassName: juicefs-sc
+
+  aws:
+    accessKeyID: ''
+    secretAccessKey: ''

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -62,10 +62,6 @@ tolerations: []
 
 affinity: {}
 
-yataiSystem:
-  namespace: "yatai-system"
-  serviceAccountName: "yatai"
-
 yatai:
   endpoint: ''
   apiToken: ''
@@ -138,6 +134,9 @@ global:
   monitorAllNamespaces: false
 
   multiTenant: false
+
+  yataiSystemNamespace: yatai-system
+  yataiSystemServiceAccountName: yatai
 
 skipCheck: false
 

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -43,10 +43,6 @@ service:
   port: 80
 
 resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -126,9 +122,11 @@ kaniko:
 estargz:
   enabled: false
 
-serviceMonitor: # need prometheus crd installed
+# The service monitor requires Prometheus CRDs to be installed to function
+serviceMonitor:
   enabled: false
 
+# Namespaces to monitor for bentorequests
 bentoRequestNamespaces: ['yatai']
 bentoRequestAllNamespaces: false
 

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -76,8 +76,6 @@ yatai:
   apiToken: ''
   clusterName: default
 
-disableYataiComponentRegistration: false
-
 dockerRegistry:
   server: ''
   inClusterServer: ''
@@ -143,3 +141,6 @@ containerImageS3Storage:
   secure: false
 
 skipCheck: false
+
+internal:
+  disableYataiComponentRegistration: true

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -106,6 +106,21 @@ kaniko:
   cacheRepo: ''
   snapshotMode: '' # options: full, redo, time
 
+builder:
+  requests: {}
+  limits: {}
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
 # The service monitor requires Prometheus CRDs to be installed to function
 serviceMonitor:
   enabled: false
@@ -121,6 +136,8 @@ global:
     accessKeyId: ""
     secretAccessKey: ""
     bucketName: ""
+
+  deploymentNamespace: yatai
 
   multiTenant: false
 

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -85,17 +85,6 @@ dockerRegistry:
   useAWSECRWithIAMRole: false
   awsECRRegion: ap-northeast-3
 
-aws:
-  accessKeyID: ''
-  secretAccessKey: ''
-  secretAccessKeyExistingSecretName: ''
-  secretAccessKeyExistingSecretKey: ''
-gcp:
-  accessKeyID: ''
-  secretAccessKey: ''
-  secretAccessKeyExistingSecretName: ''
-  secretAccessKeyExistingSecretKey: ''
-
 internalImages:
   bentoDownloader: quay.io/bentoml/bento-downloader:0.0.5
   kaniko: quay.io/bentoml/kaniko:debug

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -124,9 +124,6 @@ builder:
 serviceMonitor:
   enabled: false
 
-# Namespaces to monitor for bentorequests
-bentoRequestNamespaces: ['yatai']
-
 global:
   imagePullSecrets: []
 
@@ -137,7 +134,7 @@ global:
     secretAccessKey: ""
     bucketName: ""
 
-  deploymentNamespace: yatai
+  deploymentNamespaces: ["yatai"]
   monitorAllNamespaces: false
 
   multiTenant: false

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -126,7 +126,6 @@ serviceMonitor:
 
 # Namespaces to monitor for bentorequests
 bentoRequestNamespaces: ['yatai']
-bentoRequestAllNamespaces: false
 
 global:
   imagePullSecrets: []
@@ -139,6 +138,7 @@ global:
     bucketName: ""
 
   deploymentNamespace: yatai
+  monitorAllNamespaces: false
 
   multiTenant: false
 

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -132,13 +132,13 @@ serviceMonitor: # need prometheus crd installed
 bentoRequestNamespaces: ['yatai']
 bentoRequestAllNamespaces: false
 
-containerImageS3Storage:
-  accessKeyID: ''
-  secretAccessKey: ''
-  endpointURL: ''
-  bucket: ''
-  enableStargz: false
-  secure: false
+global:
+  s3:
+    endpoint: ""
+    secure: false
+    accessKeyId: ""
+    secretAccessKey: ""
+    bucketName: ""
 
 skipCheck: false
 

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -127,6 +127,8 @@ global:
     secretAccessKey: ""
     bucketName: ""
 
+  multiTenant: false
+
 skipCheck: false
 
 internal:

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -12,7 +12,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
@@ -130,6 +129,8 @@ bentoRequestNamespaces: ['yatai']
 bentoRequestAllNamespaces: false
 
 global:
+  imagePullSecrets: []
+
   s3:
     endpoint: ""
     secure: false

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -95,8 +95,6 @@ bentoImageBuildEngine: kaniko # options: kaniko, buildkit, buildkit-rootless
 
 addNamespacePrefixToImageName: false
 
-juicefsStorageClassName: juicefs-sc
-
 buildkit:
   cacheRepo: ''
   s3Cache:
@@ -107,9 +105,6 @@ buildkit:
 kaniko:
   cacheRepo: ''
   snapshotMode: '' # options: full, redo, time
-
-estargz:
-  enabled: false
 
 # The service monitor requires Prometheus CRDs to be installed to function
 serviceMonitor:

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -141,3 +141,4 @@ global:
 internal:
   disableYataiComponentRegistration: true
   skipCheck: false
+  juicefsStorageClassName: juicefs-sc

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -138,7 +138,6 @@ global:
   yataiSystemNamespace: yatai-system
   yataiSystemServiceAccountName: yatai
 
-skipCheck: false
-
 internal:
   disableYataiComponentRegistration: true
+  skipCheck: false

--- a/helm/yatai-image-builder/values.yaml
+++ b/helm/yatai-image-builder/values.yaml
@@ -67,7 +67,7 @@ yataiSystem:
   serviceAccountName: "yatai"
 
 yatai:
-  endpoint: http://yatai.yatai-system.svc.cluster.local
+  endpoint: ''
   apiToken: ''
   clusterName: default
 

--- a/main.go
+++ b/main.go
@@ -132,12 +132,7 @@ func main() {
 
 func verifyConfigurations(ctx context.Context) error {
 	// test s3 connection
-	rawURL := resourcescontrollers.GetContainerImageS3EndpointURL()
-	parsedURL, err := url.Parse(rawURL)
-	if err != nil {
-		return errors.Wrap(err, "failed to parse S3 endpoint URL")
-	}
-	containerImageS3EndpointURL := parsedURL.Host
+	containerImageS3EndpointURL := resourcescontrollers.GetContainerImageS3EndpointURL()
 	containerImageS3Bucket := resourcescontrollers.GetContainerImageS3Bucket()
 	containerImageS3AccessKeyID := resourcescontrollers.GetContainerImageS3AccessKeyID()
 	containerImageS3SecretAccessKey := resourcescontrollers.GetContainerImageS3SecretAccessKey()

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"flag"
-	"net/url"
 	"os"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)


### PR DESCRIPTION
- **move disableYataiComponentRegistration to internal**
- **align s3 values with serverless**
- **fix comments**
- **remove aws and gcp credentials**
- **use global.multiTenant instead of an explicit namespace prefix option**
- **remove legacy helm values**
- **add builder pod configuration**
