### PR TITLE
fix: correct spelling of 'untile' -> 'until'

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Contributing code or documentation to the project by submitting a Github pull re
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
 
 It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/) 
-which provides a reconcile function responsible for synchronizing resources untile the desired state is reached on the cluster 
+which provides a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster 
 
 ### Test It Out
 1. Install the CRDs into the cluster:


### PR DESCRIPTION
Fix typo in README.md